### PR TITLE
Give chiadoge its own keychain

### DIFF
--- a/chiadoge/util/keychain.py
+++ b/chiadoge/util/keychain.py
@@ -122,7 +122,7 @@ class Keychain:
     testing: bool
     user: str
 
-    def __init__(self, user: str = "user-chia-1.8", testing: bool = False):
+    def __init__(self, user: str = "user-chiadoge-1.8", testing: bool = False):
         self.testing = testing
         self.user = user
 


### PR DESCRIPTION
Trying to use chia's keychain causes all kinds of problems. It isn't just an import, it's using the same keychain and can cause all kinds of problems. Hopefully that wasn't the author's intention.